### PR TITLE
Convert value to string before escape it

### DIFF
--- a/ftcsv.lua
+++ b/ftcsv.lua
@@ -323,6 +323,7 @@ end
 
 -- a function that delimits " to "", used by the writer
 local function delimitField(field)
+    local field = tostring(field)
     if field:find('"') then
         return field:gsub('"', '""')
     else


### PR DESCRIPTION
Originall ftcsv will be failed when encoding a number field content
