### PR TITLE
Delmiter was not taken into account for Headers

### DIFF
--- a/ftcsv.lua
+++ b/ftcsv.lua
@@ -442,7 +442,7 @@ function ftcsv.encode(inputTable, delimiter, options)
             newHeaders[i] = headers[i]
         end
     end
-    output[1] = '"' .. table.concat(newHeaders, '","') .. '"\r\n'
+    output[1] = '"' .. table.concat(newHeaders, '"' .. delimiter .. '"') .. '"\r\n'
 
     -- add each line by line.
     for i, line in writer(inputTable, delimiter, headers) do


### PR DESCRIPTION
Headers were always separated with "," char even when other delimiter was given.
