### PR TITLE
ftcsv.parse also returns table of column headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ luarocks install ftcsv
 ## Parsing
 ### `ftcsv.parse(fileName, delimiter [, options])`
 
-ftcsv will load the entire csv file into memory, then parse it in one go, returning a lua table with the parsed data. It has only two required parameters - a file name and delimiter (limited to one character). A few optional parameters can be passed in via a table (examples below).
+ftcsv will load the entire csv file into memory, then parse it in one go, returning a lua table with the parsed data and a lua table containing the column headers. It has only two required parameters - a file name and delimiter (limited to one character). A few optional parameters can be passed in via a table (examples below).
 
 Just loading a csv file:
 ```lua
 local ftcsv = require('ftcsv')
-local zipcodes = ftcsv.parse("free-zipcode-database.csv", ",")
+local zipcodes, headers = ftcsv.parse("free-zipcode-database.csv", ",")
 ```
 
 ### Options

--- a/ftcsv.lua
+++ b/ftcsv.lua
@@ -390,7 +390,7 @@ function ftcsv.parse(inputFile, delimiter, options)
     end
 
     local output = parseString(inputString, inputLength, delimiter, i, headerField, fieldsToKeep)
-    return output
+    return output, headerField
 end
 
 -- a function that delimits " to "", used by the writer

--- a/spec/feature_spec.lua
+++ b/spec/feature_spec.lua
@@ -42,6 +42,13 @@ describe("csv features", function()
 		assert.are.same(expected, actual)
 	end)
 
+	it("should return a table with column headers", function()
+		local expected = { 'd', 'e', 'f' }
+		local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "f"}}
+		local _, actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", ",", options)
+		assert.are.same(expected, actual)
+	end)
+
 	it("should handle renaming multiple fields to the same out value", function()
 		local expected = {}
 		expected[1] = {}


### PR DESCRIPTION
output, headers = ftcsv.parse(...) -- headers = { 'Column 1', 'Column 2', ... }