### PR TITLE
Added rowTable option to ftcsv.parse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ ftcsv.parse("apple,banana,carrot", ",", {loadFromString=true, headers=false})
 
  	In the above example, the first field becomes 'a', the second field becomes 'b' and so on.
 
+ - `rowTable`
+
+ 	If you want to merge multiple CSV files, you can set `rowTable` to be an existing table to which ftcsv will append new rows.
+
+ 	Note: headers are not compared between multiple datasets.  If there is a mismatch between headers of different CSV files, then rows from each CSV file will have missing fields.
+
+ 	```lua
+ 	local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "f"}}
+	local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", ",", options)
+	options.rowTable = actual
+	ftcsv.parse("a,b,c\r\ndamson,elderberry,fig", ",", options)
+ 	```
+
 For all tested examples, take a look in /spec/feature_spec.lua
 
 

--- a/spec/feature_spec.lua
+++ b/spec/feature_spec.lua
@@ -21,6 +21,22 @@ describe("csv features", function()
 		assert.are.same(expected, actual)
 	end)
 
+	it("should handle merging multiple datasets", function()
+		local expected = {}
+		expected[1] = {}
+		expected[1].a = "apple"
+		expected[1].b = "banana"
+		expected[1].c = "carrot"
+		expected[2] = {}
+		expected[2].b = "banana"
+		expected[2].c = "carrot"
+		expected[2].d = "damson"
+		expected[2].e = "elderberry"
+		local actual = ftcsv.parse("a,b,c\napple,banana,carrot", ",", {loadFromString=true})
+		ftcsv.parse("b,c,d,e\nbanana,carrot,damson,elderberry", ",", {loadFromString=true, rowTable=actual})
+		assert.are.same(expected, actual)
+	end)
+
 	it("should handle renaming a field", function()
 		local expected = {}
 		expected[1] = {}


### PR DESCRIPTION
rowTable makes ftcsv.parse() store rows in an existing table, which
allows merging of multiple CSV files.