### PR TITLE
Optional delimiter

### DIFF
--- a/ftcsv.lua
+++ b/ftcsv.lua
@@ -397,9 +397,6 @@ local function initializeInputFromStringOrFile(inputFile, options, amount)
 end
 
 local function parseOptions(delimiter, options, fromParseLine)
-    -- delimiter MUST be one character
-    assert(#delimiter == 1 and type(delimiter) == "string", "the delimiter must be of string type and exactly one character")
-
     local fieldsToKeep = nil
 
     if options then
@@ -538,7 +535,10 @@ local function parseHeadersAndSetupArgs(inputString, delimiter, options, fieldsT
 end
 
 -- runs the show!
-function ftcsv.parse(inputFile, delimiter, options)
+function ftcsv.parse(inputFile, options)
+    local delimiter = options.delimiter or "," -- delimiter MUST be one character
+    assert(#delimiter == 1 and type(delimiter) == "string", "the delimiter must be of string type and exactly one character")
+
     local options, fieldsToKeep = parseOptions(delimiter, options, false)
 
     local inputString = initializeInputFromStringOrFile(inputFile, options, "*all")
@@ -572,7 +572,10 @@ local function initializeInputFile(inputString, options)
     return initializeInputFromStringOrFile(inputString, options, options.bufferSize)
 end
 
-function ftcsv.parseLine(inputFile, delimiter, userOptions)
+function ftcsv.parseLine(inputFile, userOptions)
+    local delimiter = userOptions.delimiter or "," -- delimiter MUST be one character
+    assert(#delimiter == 1 and type(delimiter) == "string", "the delimiter must be of string type and exactly one character")
+
     local options, fieldsToKeep = parseOptions(delimiter, userOptions, true)
     local inputString, file = initializeInputFile(inputFile, options)
 
@@ -765,9 +768,6 @@ local function getHeadersFromOptions(options)
 end
 
 local function initializeGenerator(inputTable, delimiter, options)
-    -- delimiter MUST be one character
-    assert(#delimiter == 1 and type(delimiter) == "string", "the delimiter must be of string type and exactly one character")
-
     local headers = getHeadersFromOptions(options)
     if headers == nil then
         headers = extractHeadersFromTable(inputTable)
@@ -780,7 +780,10 @@ local function initializeGenerator(inputTable, delimiter, options)
 end
 
 -- works really quickly with luajit-2.1, because table.concat life
-function ftcsv.encode(inputTable, delimiter, options)
+function ftcsv.encode(inputTable, options)
+    local delimiter = options.delimiter or "," -- delimiter MUST be one character
+    assert(#delimiter == 1 and type(delimiter) == "string", "the delimiter must be of string type and exactly one character")
+
     local output, headers = initializeGenerator(inputTable, delimiter, options)
 
     for i, line in csvLineGenerator(inputTable, delimiter, headers, options) do

--- a/spec/dynamic_features_spec.lua
+++ b/spec/dynamic_features_spec.lua
@@ -29,7 +29,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -61,7 +61,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "f"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -92,7 +92,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "e"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -123,7 +123,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, fieldsToKeep={"a", "b"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -154,7 +154,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, rename={["c"] = "b"}, fieldsToKeep={"a","b"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -185,7 +185,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, rename={["c"] = "f"}, fieldsToKeep={"a","f"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -217,7 +217,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, headerFunc=string.upper}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -248,7 +248,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, rename={["c"] = "f"}, fieldsToKeep={"A","F"}, headerFunc=string.upper}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -278,7 +278,7 @@ describe("csv features", function()
                     end
 
                     local options = {loadFromString=true}
-                    local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                    local actual, actualHeaders = ftcsv.parse(defaultString, options)
                     assert.are.same(expected, actual)
                     assert.are.same(expectedHeaders, actualHeaders)
                 end)
@@ -315,7 +315,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, headers=false}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -347,7 +347,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, headers=false}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -383,7 +383,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, headers=false, rename={"a","b","c"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -417,7 +417,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, headers=false, rename={"a","b","c"}, fieldsToKeep={"a","b"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -451,7 +451,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, headers=false, rename={"a","b"}, fieldsToKeep={"a","b"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -481,7 +481,7 @@ describe("csv features", function()
                     end
 
                     local options = {loadFromString=true, ignoreQuotes=true}
-                    local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                    local actual, actualHeaders = ftcsv.parse(defaultString, options)
                     assert.are.same(expected, actual)
                     assert.are.same(expectedHeaders, actualHeaders)
                 end)

--- a/spec/error_spec.lua
+++ b/spec/error_spec.lua
@@ -14,7 +14,7 @@ describe("csv decode error", function()
 	for _, value in ipairs(files) do
 		it("should error out " .. value[1], function()
 			local test = function()
-				ftcsv.parse("spec/bad_csvs/" .. value[1] .. ".csv", ",")
+				ftcsv.parse("spec/bad_csvs/" .. value[1] .. ".csv")
 			end
 			assert.has_error(test, value[2])
 		end)
@@ -23,8 +23,8 @@ end)
 
 it("should error out for fieldsToKeep if no headers and no renaming takes place", function()
 	local test = function()
-		local options = {loadFromString=true, headers=false, fieldsToKeep={1, 2}}
-		ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, fieldsToKeep={1, 2}, delimiter=">"}
+		ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", options)
 	end
 	assert.has_error(test, "ftcsv: fieldsToKeep only works with header-less files when using the 'rename' functionality")
 end)
@@ -37,7 +37,7 @@ it("should error out when you want to encode a table and specify a field that do
 	}
 
 	local test = function()
-		ftcsv.encode(encodeThis, ">", {fieldsToKeep={"c"}})
+		ftcsv.encode(encodeThis, {fieldsToKeep={"c"}, delimiter=">"})
 	end
 
 	assert.has_error(test, "ftcsv: the field 'c' doesn't exist in the inputTable")
@@ -47,7 +47,7 @@ describe("parseLine features small, nonworking buffer size", function()
     it("should error out when trying to load from string", function()
         local test = function()
             local parse = {}
-            for i, line in ftcsv.parseLine("a,b,c\n1,2,3", ",", {loadFromString=true}) do
+            for i, line in ftcsv.parseLine("a,b,c\n1,2,3", {loadFromString=true}) do
                 parse[i] = line
             end
             return parse
@@ -58,14 +58,14 @@ end)
 
 it("should error when dealing with quotes", function()
 	local test = function()
-		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true})
+		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', {loadFromString=true})
 	end
 	assert.has_error(test, "ftcsv: can't find closing quote in row 1. Try running with the option ignoreQuotes=true if the source incorrectly uses quotes.")
 end)
 
 it("should error if bufferSize is set when parsing entire files", function()
 	local test = function()
-		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true, bufferSize=34})
+		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', {loadFromString=true, bufferSize=34})
 	end
 	assert.has_error(test, "ftcsv: bufferSize can only be specified using 'parseLine'. When using 'parse', the entire file is read into memory")
 end)

--- a/spec/feature_spec.lua
+++ b/spec/feature_spec.lua
@@ -7,7 +7,7 @@ describe("csv features", function()
 		expected[1].a = "apple"
 		expected[1].b = "banana"
 		expected[1].c = "carrot"
-		local actual = ftcsv.parse("a,b,c\napple,banana,carrot", ",", {loadFromString=true})
+		local actual = ftcsv.parse("a,b,c\napple,banana,carrot", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -17,7 +17,7 @@ describe("csv features", function()
 		expected[1].a = "apple"
 		expected[1].b = "banana"
 		expected[1].c = "carrot"
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", ",", {loadFromString=true})
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -27,7 +27,7 @@ describe("csv features", function()
 		expected[1].a = "apple"
 		expected[1].b = "banana"
 		expected[1].c = "carrot"
-		local actual = ftcsv.parse("a,b,c\rapple,banana,carrot", ",", {loadFromString=true})
+		local actual = ftcsv.parse("a,b,c\rapple,banana,carrot", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -37,7 +37,7 @@ describe("csv features", function()
 		expected[1].a = "apple"
 		expected[1].b = "banana"
 		expected[1].c = "carrot"
-		local actual = ftcsv.parse('"a","b","c"\n"apple","banana","carrot"', ",", {loadFromString=true})
+		local actual = ftcsv.parse('"a","b","c"\n"apple","banana","carrot"', {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -47,7 +47,7 @@ describe("csv features", function()
 		expected[1].a = '"apple"'
 		expected[1].b = '"banana"'
 		expected[1].c = '"carrot"'
-		local actual = ftcsv.parse('"a","b","c"\n"""apple""","""banana""","""carrot"""', ",", {loadFromString=true})
+		local actual = ftcsv.parse('"a","b","c"\n"""apple""","""banana""","""carrot"""', {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -57,7 +57,7 @@ describe("csv features", function()
 		expected[1].a = '"apple"'
 		expected[1].b = 'banana'
 		expected[1].c = '"carrot"'
-		local actual = ftcsv.parse('"a","b","c"\n"""apple""","banana","""carrot"""', ",", {loadFromString=true})
+		local actual = ftcsv.parse('"a","b","c"\n"""apple""","banana","""carrot"""', {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -67,7 +67,7 @@ describe("csv features", function()
 		expected[1].a = 'A"B""C'
 		expected[1].b = 'A""B"C'
 		expected[1].c = 'A"""B""C'
-		local actual = ftcsv.parse('a;b;c\n"A""B""""C";"A""""B""C";"A""""""B""""C"', ";", {loadFromString=true})
+		local actual = ftcsv.parse('a;b;c\n"A""B""""C";"A""""B""C";"A""""""B""""C"', {loadFromString=true, delimiter=";"})
 		assert.are.same(expected, actual)
 	end)
 
@@ -77,7 +77,7 @@ describe("csv features", function()
 		expected[1].d = "apple"
 		expected[1].b = "banana"
 		expected[1].c = "carrot"
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", ",", {loadFromString=true, rename={["a"] = "d"}})
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", {loadFromString=true, rename={["a"] = "d"}})
 		assert.are.same(expected, actual)
 	end)
 
@@ -88,14 +88,14 @@ describe("csv features", function()
 		expected[1].e = "banana"
 		expected[1].f = "carrot"
 		local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "f"}}
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", ",", options)
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", options)
 		assert.are.same(expected, actual)
 	end)
 
 	it("should return a table with column headers", function()
 		local expected = { 'd', 'e', 'f' }
 		local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "f"}}
-		local _, actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", ",", options)
+		local _, actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -105,7 +105,7 @@ describe("csv features", function()
 		expected[1].d = "apple"
 		expected[1].e = "carrot"
 		local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "e"}}
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", ",", options)
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -115,7 +115,7 @@ describe("csv features", function()
 		expected[1].d = "apple"
 		expected[1].e = "carrot"
 		local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "e"}}
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", ",", options)
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -125,7 +125,7 @@ describe("csv features", function()
 		expected[1].a = "apple"
 		expected[1].b = "banana"
 		local options = {loadFromString=true, fieldsToKeep={"a","b"}}
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", ",", options)
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -135,7 +135,7 @@ describe("csv features", function()
 		expected[1].a = "apple"
 		expected[1].b = "carrot"
 		local options = {loadFromString=true, fieldsToKeep={"a","b"}, rename={["c"] = "b"}}
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", ",", options)
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -145,7 +145,7 @@ describe("csv features", function()
 		expected[1].a = "apple"
 		expected[1].f = "carrot"
 		local options = {loadFromString=true, fieldsToKeep={"a","f"}, rename={["c"] = "f"}}
-		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", ",", options)
+		local actual = ftcsv.parse("a,b,c\r\napple,banana,carrot\r\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -159,8 +159,8 @@ describe("csv features", function()
 		expected[2][1] = "diamond"
 		expected[2][2] = "emerald"
 		expected[2][3] = "pearl"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -174,8 +174,8 @@ describe("csv features", function()
 		expected[2][1] = "diamond"
 		expected[2][2] = "emerald"
 		expected[2][3] = "pearl"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>\ndiamond>emerald>pearl", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -185,8 +185,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = "carrot"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>carrot", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -196,8 +196,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = ""
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -207,8 +207,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = "carrot"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse('"apple">"banana">"carrot"', ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse('"apple">"banana">"carrot"', options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -218,8 +218,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = ""
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse('"apple">"banana">', ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse('"apple">"banana">', options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -233,8 +233,8 @@ describe("csv features", function()
 		expected[2][1] = "diamond"
 		expected[2][2] = "emerald"
 		expected[2][3] = "pearl"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse('"apple">"banana">"carrot"\n"diamond">"emerald">"pearl"', ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse('"apple">"banana">"carrot"\n"diamond">"emerald">"pearl"', options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -248,8 +248,8 @@ describe("csv features", function()
 		expected[2][1] = "diamond"
 		expected[2][2] = "emerald"
 		expected[2][3] = "pearl"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse('"apple">"banana">\n"diamond">"emerald">"pearl"', ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse('"apple">"banana">\n"diamond">"emerald">"pearl"', options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -259,8 +259,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = "carrot"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>carrot\n", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -270,8 +270,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = ""
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>\n", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -281,8 +281,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = "carrot"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>carrot\r\n", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot\r\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -292,8 +292,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = ""
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>\r\n", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>\r\n", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -303,8 +303,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = "carrot"
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>carrot\r", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot\r", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -314,8 +314,8 @@ describe("csv features", function()
 		expected[1][1] = "apple"
 		expected[1][2] = "banana"
 		expected[1][3] = ""
-		local options = {loadFromString=true, headers=false}
-		local actual = ftcsv.parse("apple>banana>\r", ">", options)
+		local options = {loadFromString=true, headers=false, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>\r", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -330,8 +330,8 @@ describe("csv features", function()
 		expected[2].a = "diamond"
 		expected[2].b = "emerald"
 		expected[2].c = "pearl"
-		local options = {loadFromString=true, headers=false, rename={"a","b","c"}}
-		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, rename={"a","b","c"}, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -345,8 +345,8 @@ describe("csv features", function()
 		expected[2].a = "diamond"
 		expected[2].b = "emerald"
 		expected[2].c = "pearl"
-		local options = {loadFromString=true, headers=false, rename={"a","b","c"}}
-		local actual = ftcsv.parse("apple>banana>\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, rename={"a","b","c"}, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>\ndiamond>emerald>pearl", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -358,8 +358,8 @@ describe("csv features", function()
 		expected[2] = {}
 		expected[2].a = "diamond"
 		expected[2].b = "emerald"
-		local options = {loadFromString=true, headers=false, rename={"a","b","c"}, fieldsToKeep={"a","b"}}
-		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, rename={"a","b","c"}, fieldsToKeep={"a","b"}, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -371,8 +371,8 @@ describe("csv features", function()
 		expected[2] = {}
 		expected[2].a = "diamond"
 		expected[2].b = "emerald"
-		local options = {loadFromString=true, headers=false, rename={"a","b","c"}, fieldsToKeep={"a","b"}}
-		local actual = ftcsv.parse("apple>>carrot\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, rename={"a","b","c"}, fieldsToKeep={"a","b"}, delimiter=">"}
+		local actual = ftcsv.parse("apple>>carrot\ndiamond>emerald>pearl", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -384,8 +384,8 @@ describe("csv features", function()
 		expected[2] = {}
 		expected[2].a = "diamond"
 		expected[2].b = "emerald"
-		local options = {loadFromString=true, headers=false, rename={"a","b"}, fieldsToKeep={"a","b"}}
-		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", ">", options)
+		local options = {loadFromString=true, headers=false, rename={"a","b"}, fieldsToKeep={"a","b"}, delimiter=">"}
+		local actual = ftcsv.parse("apple>banana>carrot\ndiamond>emerald>pearl", options)
 		assert.are.same(expected, actual)
 	end)
 
@@ -395,7 +395,7 @@ describe("csv features", function()
 		expected[1].A = "apple"
 		expected[1].B = "banana"
 		expected[1].C = "carrot"
-		local actual = ftcsv.parse("a,b,c\napple,banana,carrot", ",", {loadFromString=true, headerFunc=string.upper})
+		local actual = ftcsv.parse("a,b,c\napple,banana,carrot", {loadFromString=true, headerFunc=string.upper})
 		assert.are.same(expected, actual)
 	end)
 
@@ -405,8 +405,8 @@ describe("csv features", function()
 		expected[1].A = "apple"
 		expected[1].B = "banana"
 		expected[1].C = "carrot"
-		local actual = ftcsv.parse(ftcsv.encode(expected, ","), ",", {loadFromString=true})
-		local expected = ftcsv.parse("A,B,C\napple,banana,carrot", ",", {loadFromString=true})
+		local actual = ftcsv.parse(ftcsv.encode(expected), {loadFromString=true})
+		local expected = ftcsv.parse("A,B,C\napple,banana,carrot", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -416,8 +416,8 @@ describe("csv features", function()
 		expected[1].A = "apple"
 		expected[1].B = "banana"
 		expected[1].C = "carrot"
-		local actual = ftcsv.parse(ftcsv.encode(expected, ">"), ">", {loadFromString=true})
-		local expected = ftcsv.parse("A,B,C\napple,banana,carrot", ",", {loadFromString=true})
+		local actual = ftcsv.parse(ftcsv.encode(expected, {delimiter=">"}), {loadFromString=true, delimiter=">"})
+		local expected = ftcsv.parse("A,B,C\napple,banana,carrot", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -427,8 +427,8 @@ describe("csv features", function()
 		expected[1].A = "apple"
 		expected[1].B = "banana"
 		expected[1].C = "carrot"
-		local actual = ftcsv.parse(ftcsv.encode(expected, ",", {fieldsToKeep={"A", "B"}}), ",", {loadFromString=true})
-		local expected = ftcsv.parse("A,B\napple,banana", ",", {loadFromString=true})
+		local actual = ftcsv.parse(ftcsv.encode(expected, {fieldsToKeep={"A", "B"}}), {loadFromString=true})
+		local expected = ftcsv.parse("A,B\napple,banana", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -436,7 +436,7 @@ describe("csv features", function()
 		local expected = '"a","b","c","d"\r\n"1","","foo","""quoted"""\r\n'
 		output = ftcsv.encode({
 			{ a = 1, b = '', c = 'foo', d = '"quoted"' };
-		}, ',')
+		})
 		assert.are.same(expected, output)
 	end)
 
@@ -452,7 +452,7 @@ describe("csv features", function()
 		local expected = 'a,b,c,d\r\n1,,"fo,o","""quoted"""\r\n'
 		output = ftcsv.encode({
 			{ a = 1, b = '', c = 'fo,o', d = '"quoted"' };
-		}, ',', {onlyRequiredQuotes=true})
+		}, {onlyRequiredQuotes=true})
 		assert.are.same(expected, output)
 	end)
 
@@ -460,7 +460,7 @@ describe("csv features", function()
 		local expected = 'a>b>c>d\r\n1>>fo,o>"""quoted"""\r\n'
 		output = ftcsv.encode({
 			{ a = 1, b = '', c = 'fo,o', d = '"quoted"' };
-		}, '>', {onlyRequiredQuotes=true})
+		}, {onlyRequiredQuotes=true, delimiter=">"})
 		assert.are.same(expected, output)
 	end)
 
@@ -468,7 +468,7 @@ describe("csv features", function()
 		local expected = "b,c\r\n,foo\r\n"
 		output = ftcsv.encode({
 			{ a = 1, b = '', c = 'foo', d = '"quoted"' };
-		}, ',', {onlyRequiredQuotes=true, fieldsToKeep={"b", "c"}})
+		}, {onlyRequiredQuotes=true, fieldsToKeep={"b", "c"}})
 		assert.are.same(expected, output)
 	end)
 
@@ -478,7 +478,7 @@ describe("csv features", function()
 		expected[1]["]] print('hello')"] = "apple"
 		expected[1].b = "banana"
 		expected[1].c = "carrot"
-		local actual = ftcsv.parse("]] print('hello'),b,c\napple,banana,carrot", ",", {loadFromString=true})
+		local actual = ftcsv.parse("]] print('hello'),b,c\napple,banana,carrot", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -488,7 +488,7 @@ describe("csv features", function()
 		expected[1].a = '"apple'
 		expected[1].b = "banana"
 		expected[1].c = "carrot"
-		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true, ignoreQuotes=true})
+		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', {loadFromString=true, ignoreQuotes=true})
 		assert.are.same(expected, actual)
 	end)
 

--- a/spec/parseLine_spec.lua
+++ b/spec/parseLine_spec.lua
@@ -14,7 +14,7 @@ describe("parseLine features small, working buffer size", function()
         local json = loadFile("spec/json/correctness.json")
         json = cjson.decode(json)
         local parse = {}
-        for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", ",", {bufferSize=52}) do
+        for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=52}) do
             assert.are.same(json[i], line)
             parse[i] = line
         end
@@ -27,7 +27,7 @@ describe("parseLine features small, nonworking buffer size", function()
     it("should handle correctness", function()
         local test = function()
             local parse = {}
-            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", ",", {bufferSize=63}) do
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=63}) do
                 parse[i] = line
             end
             return parse
@@ -40,7 +40,7 @@ describe("parseLine features smaller, nonworking buffer size", function()
     it("should handle correctness", function()
         local test = function()
             local parse = {}
-            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", ",", {bufferSize=50}) do
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=50}) do
                 parse[i] = line
             end
             return parse
@@ -53,7 +53,7 @@ describe("smaller bufferSize than header and incorrect number of fields", functi
     it("should handle correctness", function()
         local test = function()
             local parse = {}
-            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", ",", {bufferSize=23}) do
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=23}) do
                 parse[i] = line
             end
             return parse
@@ -66,7 +66,7 @@ describe("smaller bufferSize than header, but with correct field numbers", funct
     it("should handle correctness", function()
         local test = function()
             local parse = {}
-            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", ",", {bufferSize=30}) do
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=30}) do
                 parse[i] = line
             end
             return parse
@@ -80,7 +80,7 @@ describe("parseLine with options but not bufferSize", function()
         local json = loadFile("spec/json/correctness.json")
         json = cjson.decode(json)
     local parse = {}
-    for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", ",", {rename={["Year"] = "Full Year"}}) do
+    for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {rename={["Year"] = "Full Year"}}) do
 	parse[i] = line
     end
         assert.are.same(#json, #parse)

--- a/spec/parse_encode_spec.lua
+++ b/spec/parse_encode_spec.lua
@@ -36,7 +36,7 @@ describe("csv decode", function()
 		it("should handle " .. value, function()
 			local json = loadFile("spec/json/" .. value .. ".json")
 			json = cjson.decode(json)
-			local parse = ftcsv.parse("spec/csvs/" .. value .. ".csv", ",")
+			local parse = ftcsv.parse("spec/csvs/" .. value .. ".csv")
 			assert.are.same(#json, #parse)
 			assert.are.same(json, parse)
 		end)
@@ -49,7 +49,7 @@ describe("csv parseLine decode", function()
 			local json = loadFile("spec/json/" .. value .. ".json")
 			json = cjson.decode(json)
 			local parse = {}
-			for i, v in ftcsv.parseLine("spec/csvs/" .. value .. ".csv", ",") do
+			for i, v in ftcsv.parseLine("spec/csvs/" .. value .. ".csv") do
 				parse[i] = v
 				assert.are.same(json[i], v)
 			end
@@ -65,7 +65,7 @@ describe("csv decode from string", function()
 			local contents = loadFile("spec/csvs/" .. value .. ".csv")
 			local json = loadFile("spec/json/" .. value .. ".json")
 			json = cjson.decode(json)
-			local parse = ftcsv.parse(contents, ",", {loadFromString=true})
+			local parse = ftcsv.parse(contents, {loadFromString=true})
 			assert.are.same(json, parse)
 		end)
 	end
@@ -76,8 +76,8 @@ describe("csv encode", function()
 		it("should handle " .. value, function()
 			local jsonFile = loadFile("spec/json/" .. value .. ".json")
 			local jsonDecode = cjson.decode(jsonFile)
-			-- local parse = staecsv:ftcsv(contents, ",")
-			local reEncoded = ftcsv.parse(ftcsv.encode(jsonDecode, ","), ",", {loadFromString=true})
+			-- local parse = staecsv:ftcsv(contents)
+			local reEncoded = ftcsv.parse(ftcsv.encode(jsonDecode), {loadFromString=true})
 			-- local f = csv.openstring(contents, {separator=",", header=true})
 			-- local parse = {}
 			-- for fields in f:lines() do
@@ -94,7 +94,7 @@ describe("csv encode without quotes", function()
 			local jsonFile = loadFile("spec/json/" .. value .. ".json")
 			local jsonDecode = cjson.decode(jsonFile)
 			-- local parse = staecsv:ftcsv(contents, ",")
-			local reEncodedNoQuotes = ftcsv.parse(ftcsv.encode(jsonDecode, ",", {onlyRequiredQuotes=true}), ",", {loadFromString=true})
+			local reEncodedNoQuotes = ftcsv.parse(ftcsv.encode(jsonDecode, {onlyRequiredQuotes=true}), {loadFromString=true})
 			-- local f = csv.openstring(contents, {separator=",", header=true})
 			-- local parse = {}
 			-- for fields in f:lines() do


### PR DESCRIPTION
## Features
* The delimiter is now an optional argument that defaults to the comma character `,` (since ya know, this is a CSV library)
* The delimiter has been moved to the options table in case the user wants to change it
* All unit tests have been updated to accommodate the new changes

Closes #23
