### PR TITLE
Change GitHub Actions to run on open pull requests

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
     tags: [ '*.*.*' ]
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
 
 jobs:
   test:

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
     tags: [ '*.*.*' ]
   pull_request:
-    branches: [ master ]
+    types: [opened]
 
 jobs:
   test:


### PR DESCRIPTION
## Features
* GitHub Actions will now run on any (re)open pull request

We want to be able to test out any new code being merged into the main repo.  GitHub gives open source repositories free use of GitHub Actions.  See:

https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits

They give plenty of resources and time for GitHub runners and I doubt your repo will ever have to worry about hitting limits.