### PR TITLE
Add Lua linter to github actions

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,18 @@
+name: Luacheck
+
+on:
+  pull_request:
+  push: 
+    branches: 
+      - master
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Luacheck
+        uses: lunarmodules/luacheck@v1
+        with:
+          args: . --std max+busted

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,1 @@
+std = "max+busted"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "luacheck.useLuacheck": true
+}

--- a/ftcsv.lua
+++ b/ftcsv.lua
@@ -1,3 +1,6 @@
+--- ftcsv is a fast CSV library written for Lua
+--- It's been tested with LuaJIT 2.0/2.1 and Lua 5.1, 5.2, 5.3, and 5.4
+-- @module ftcsv
 local ftcsv = {
     _VERSION = 'ftcsv 1.3.0',
     _DESCRIPTION = 'CSV library for Lua',
@@ -48,7 +51,8 @@ if type(jit) == 'table' then
     luaCompatibility.LuaJIT = true
     -- finds the end of an escape sequence
     function luaCompatibility.findClosingQuote(i, inputLength, inputString, quote, doubleQuoteEscape)
-        local currentChar, nextChar = sbyte(inputString, i), nil
+        local currentChar = sbyte(inputString, i)
+	local nextChar
         while i <= inputLength do
             nextChar = sbyte(inputString, i+1)
 
@@ -88,9 +92,8 @@ else
     end
 end
 
-
 -- determine the real headers as opposed to the header mapping
-local function determineRealHeaders(headerField, fieldsToKeep) 
+local function determineRealHeaders(headerField, fieldsToKeep)
     local realHeaders = {}
     local headerSet = {}
     for i = 1, #headerField do
@@ -106,7 +109,6 @@ local function determineRealHeaders(headerField, fieldsToKeep)
     end
     return realHeaders
 end
-
 
 local function determineTotalColumnCount(headerField, fieldsToKeep)
     local totalColumnCount = 0
@@ -143,7 +145,8 @@ local function parseString(inputString, i, options)
 
     -- keep track of my chars!
     local inputLength = options.inputLength or #inputString
-    local currentChar, nextChar = sbyte(inputString, i), nil
+    local currentChar = sbyte(inputString, i)
+    local nextChar
     local skipChar = 0
     local field
     local fieldStart = i
@@ -237,7 +240,9 @@ local function parseString(inputString, i, options)
                 emptyIdentified = false
             end
             skipChar = 1
-            i, doubleQuoteEscape = luaCompatibility.findClosingQuote(i+1, inputLength, inputString, quote, doubleQuoteEscape)
+            i, doubleQuoteEscape = luaCompatibility.findClosingQuote(
+                i+1, inputLength, inputString, quote, doubleQuoteEscape
+            )
 
         -- create some fields
         elseif currentChar == delimiterByte then
@@ -291,7 +296,7 @@ local function parseString(inputString, i, options)
                 return outResults, lineStart
             else
                 error("ftcsv: can't find closing quote in row " .. options.rowOffset + lineNum ..
-                 ". Try running with the option ignoreQuotes=true if the source incorrectly uses quotes.")
+                ". Try running with the option ignoreQuotes=true if the source incorrectly uses quotes.")
             end
         end
 
@@ -398,22 +403,39 @@ end
 
 local function parseOptions(delimiter, options, fromParseLine)
     -- delimiter MUST be one character
-    assert(#delimiter == 1 and type(delimiter) == "string", "the delimiter must be of string type and exactly one character")
+    assert(
+        #delimiter == 1 and type(delimiter) == "string",
+        "the delimiter must be of string type and exactly one character"
+    )
 
     local fieldsToKeep = nil
 
     if options then
 
-	if options.headers ~= nil then
-            assert(type(options.headers) == "boolean", "ftcsv only takes the boolean 'true' or 'false' for the optional parameter 'headers' (default 'true'). You passed in '" .. tostring(options.headers) .. "' of type '" .. type(options.headers) .. "'.")
+	    if options.headers ~= nil then
+            assert(
+                type(options.headers) == "boolean",
+                "ftcsv only takes the boolean 'true' or 'false' for the optional parameter " ..
+                "'headers' (default 'true'). You passed in '" .. tostring(options.headers) ..
+                "' of type '" .. type(options.headers) .. "'."
+            )
         end
 
-	if options.rename ~= nil then
-            assert(type(options.rename) == "table", "ftcsv only takes in a key-value table for the optional parameter 'rename'. You passed in '" .. tostring(options.rename) .. "' of type '" .. type(options.rename) .. "'.")
+	    if options.rename ~= nil then
+            assert(
+                type(options.rename) == "table",
+                "ftcsv only takes in a key-value table for the optional parameter 'rename'. " ..
+                "You passed in '" .. tostring(options.rename) .. "' of type '" .. type(options.rename) .. "'."
+            )
         end
 
-	if options.fieldsToKeep ~= nil then
-            assert(type(options.fieldsToKeep) == "table", "ftcsv only takes in a list (as a table) for the optional parameter 'fieldsToKeep'. You passed in '" .. tostring(options.fieldsToKeep) .. "' of type '" .. type(options.fieldsToKeep) .. "'.")
+	    if options.fieldsToKeep ~= nil then
+            assert(
+                type(options.fieldsToKeep) == "table",
+                "ftcsv only takes in a list (as a table) for the optional parameter 'fieldsToKeep'. " ..
+                "You passed in '" .. tostring(options.fieldsToKeep) .. "' of type '" .. type(options.fieldsToKeep) ..
+                "'."
+            )
             local ofieldsToKeep = options.fieldsToKeep
             if ofieldsToKeep ~= nil then
                 fieldsToKeep = {}
@@ -426,26 +448,45 @@ local function parseOptions(delimiter, options, fromParseLine)
             end
         end
 
-	if options.loadFromString ~= nil then
-            assert(type(options.loadFromString) == "boolean", "ftcsv only takes a boolean value for optional parameter 'loadFromString'. You passed in '" .. tostring(options.loadFromString) .. "' of type '" .. type(options.loadFromString) .. "'.")
+	    if options.loadFromString ~= nil then
+            assert(
+                type(options.loadFromString) == "boolean",
+                "ftcsv only takes a boolean value for optional parameter 'loadFromString'. You passed in '" ..
+                tostring(options.loadFromString) .. "' of type '" .. type(options.loadFromString) .. "'."
+            )
         end
 
-	if options.headerFunc ~= nil then
-            assert(type(options.headerFunc) == "function", "ftcsv only takes a function value for optional parameter 'headerFunc'. You passed in '" .. tostring(options.headerFunc) .. "' of type '" .. type(options.headerFunc) .. "'.")
+	    if options.headerFunc ~= nil then
+            assert(
+                type(options.headerFunc) == "function",
+                "ftcsv only takes a function value for optional parameter 'headerFunc'. You passed in '" ..
+                tostring(options.headerFunc) .. "' of type '" .. type(options.headerFunc) .. "'."
+            )
         end
 
-	if options.ignoreQuotes == nil then
+	    if options.ignoreQuotes == nil then
             options.ignoreQuotes = false
         else
-            assert(type(options.ignoreQuotes) == "boolean", "ftcsv only takes a boolean value for optional parameter 'ignoreQuotes'. You passed in '" .. tostring(options.ignoreQuotes) .. "' of type '" .. type(options.ignoreQuotes) .. "'.")
+            assert(
+                type(options.ignoreQuotes) == "boolean",
+                "ftcsv only takes a boolean value for optional parameter 'ignoreQuotes'. You passed in '" ..
+                tostring(options.ignoreQuotes) .. "' of type '" .. type(options.ignoreQuotes) .. "'."
+            )
         end
 
-	if options.bufferSize == nil then
-	    options.bufferSize = 2^16
-	else
-            assert(type(options.bufferSize) == "number", "ftcsv only takes a number value for optional parameter 'bufferSize'. You passed in '" .. tostring(options.bufferSize) .. "' of type '" .. type(options.bufferSize) .. "'.")
+	    if options.bufferSize == nil then
+	        options.bufferSize = 2^16
+	    else
+            assert(
+                type(options.bufferSize) == "number",
+                "ftcsv only takes a number value for optional parameter 'bufferSize'. You passed in '" ..
+                tostring(options.bufferSize) .. "' of type '" .. type(options.bufferSize) .. "'."
+            )
             if fromParseLine == false then
-                error("ftcsv: bufferSize can only be specified using 'parseLine'. When using 'parse', the entire file is read into memory")
+                error(
+                "ftcsv: bufferSize can only be specified using 'parseLine'. When using 'parse', " ..
+                "the entire file is read into memory"
+            )
             end
         end
 
@@ -539,11 +580,13 @@ end
 
 -- runs the show!
 function ftcsv.parse(inputFile, delimiter, options)
-    local options, fieldsToKeep = parseOptions(delimiter, options, false)
+    local optionsCSV, fieldsToKeep = parseOptions(delimiter, options, false)
 
-    local inputString = initializeInputFromStringOrFile(inputFile, options, "*all")
+    local inputString = initializeInputFromStringOrFile(inputFile, optionsCSV, "*all")
 
-    local endOfHeaders, parserArgs, finalHeaders = parseHeadersAndSetupArgs(inputString, delimiter, options, fieldsToKeep, true)
+    local endOfHeaders, parserArgs, finalHeaders = parseHeadersAndSetupArgs(
+        inputString, delimiter, optionsCSV, fieldsToKeep, true
+    )
 
     local output = parseString(inputString, endOfHeaders, parserArgs)
 
@@ -576,12 +619,12 @@ function ftcsv.parseLine(inputFile, delimiter, userOptions)
     local options, fieldsToKeep = parseOptions(delimiter, userOptions, true)
     local inputString, file = initializeInputFile(inputFile, options)
 
+    local fileSize = getFileSize(file) or 0
+    local atEndOfFile = determineAtEndOfFile(file, fileSize) or false
 
-    local fileSize, atEndOfFile = 0, false
-    fileSize = getFileSize(file)
-    atEndOfFile = determineAtEndOfFile(file, fileSize)
-
-    local endOfHeaders, parserArgs, _ = parseHeadersAndSetupArgs(inputString, delimiter, options, fieldsToKeep, atEndOfFile)
+    local endOfHeaders, parserArgs, _ = parseHeadersAndSetupArgs(
+        inputString, delimiter, options, fieldsToKeep, atEndOfFile
+    )
     parserArgs.buffered = true
     parserArgs.endOfFile = atEndOfFile
 
@@ -630,12 +673,8 @@ function ftcsv.parseLine(inputFile, delimiter, userOptions)
     end
 end
 
-
-
 -- The ENCODER code is below here
 -- This could be broken out, but is kept here for portability
-
-
 local function delimitField(field)
     field = tostring(field)
     if field:find('"') then
@@ -729,12 +768,12 @@ end
 
 local function escapeHeadersForOutput(headers, delimiter, options)
     local escapedHeaders = {}
-    local delimitField = delimitField
+    local delimitFunction = delimitField
     if options and options.onlyRequiredQuotes == true then
-        delimitField = generateDelimitAndQuoteField(delimiter)
+        delimitFunction = generateDelimitAndQuoteField(delimiter)
     end
     for i = 1, #headers do
-        escapedHeaders[i] = delimitField(headers[i])
+        escapedHeaders[i] = delimitFunction(headers[i])
     end
 
     return escapedHeaders
@@ -757,7 +796,10 @@ local function getHeadersFromOptions(options)
     if options then
         if options.fieldsToKeep ~= nil then
             assert(
-                type(options.fieldsToKeep) == "table", "ftcsv only takes in a list (as a table) for the optional parameter 'fieldsToKeep'. You passed in '" .. tostring(options.headers) .. "' of type '" .. type(options.headers) .. "'.")
+                type(options.fieldsToKeep) == "table",
+                "ftcsv only takes in a list (as a table) for the optional parameter 'fieldsToKeep'. You passed in '" ..
+                tostring(options.headers) .. "' of type '" .. type(options.headers) .. "'."
+            )
             headers = options.fieldsToKeep
         end
     end
@@ -766,7 +808,10 @@ end
 
 local function initializeGenerator(inputTable, delimiter, options)
     -- delimiter MUST be one character
-    assert(#delimiter == 1 and type(delimiter) == "string", "the delimiter must be of string type and exactly one character")
+    assert(
+        #delimiter == 1 and type(delimiter) == "string",
+        "the delimiter must be of string type and exactly one character"
+    )
 
     local headers = getHeadersFromOptions(options)
     if headers == nil then
@@ -792,4 +837,3 @@ function ftcsv.encode(inputTable, delimiter, options)
 end
 
 return ftcsv
-

--- a/spec/dynamic_features_spec.lua
+++ b/spec/dynamic_features_spec.lua
@@ -136,7 +136,8 @@ describe("csv features", function()
         for newline, j in pairs(newlines) do
             for quote, k in pairs(quotes) do
                 for _, endline in ipairs(endlines) do
-                    local name = "should handle only keeping a few fields with a rename to an existing field (%s + %s + %s) EOF: %s"
+                    local name = "should handle only keeping a few fields with a rename to an existing field " ..
+                    "(%s + %s + %s) EOF: %s"
                     it(name:format(bom, newline, quote, endline), function()
                         local expectedHeaders = {"a", "b"}
                         local expected = {}
@@ -167,7 +168,8 @@ describe("csv features", function()
         for newline, j in pairs(newlines) do
             for quote, k in pairs(quotes) do
                 for _, endline in ipairs(endlines) do
-                    local name = "should handle only keeping a few fields with a rename to a new field (%s + %s + %s) EOF: %s"
+                    local name = "should handle only keeping a few fields with a rename to a new field " ..
+                    "(%s + %s + %s) EOF: %s"
                     it(name:format(bom, newline, quote, endline), function()
                         local expectedHeaders = {"a", "f"}
                         local expected = {}
@@ -230,7 +232,8 @@ describe("csv features", function()
         for newline, j in pairs(newlines) do
             for quote, k in pairs(quotes) do
                 for _, endline in ipairs(endlines) do
-                    local name = "should apply a function via headerFunc with rename and fieldsToKeep (%s + %s + %s) EOF: %s"
+                    local name = "should apply a function via headerFunc with rename and fieldsToKeep " ..
+                    "(%s + %s + %s) EOF: %s"
                     it(name:format(bom, newline, quote, endline), function()
                         local expectedHeaders = {"A", "F"}
                         local expected = {}
@@ -247,7 +250,12 @@ describe("csv features", function()
                             defaultString = defaultString:format(i, j, j)
                         end
 
-                        local options = {loadFromString=true, rename={["c"] = "f"}, fieldsToKeep={"A","F"}, headerFunc=string.upper}
+                        local options = {
+                            loadFromString=true,
+                            rename={["c"] = "f"},
+                            fieldsToKeep={"A","F"},
+                            headerFunc=string.upper
+                        }
                         local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
@@ -396,7 +404,8 @@ describe("csv features", function()
         for newline, j in pairs(newlines) do
             for quote, k in pairs(quotes) do
                 for _, endline in ipairs(endlines) do
-                    local name = "should handle renaming fields from files without headers and only keeping a few fields (%s + %s + %s) EOF: %s"
+                    local name = "should handle renaming fields from files without headers and only keeping a few " ..
+                    "fields (%s + %s + %s) EOF: %s"
                     it(name:format(bom, newline, quote, endline), function()
                         local expectedHeaders = {"a", "b"}
                         local expected = {}
@@ -416,7 +425,12 @@ describe("csv features", function()
                             defaultString = defaultString:format(i, j, j)
                         end
 
-                        local options = {loadFromString=true, headers=false, rename={"a","b","c"}, fieldsToKeep={"a","b"}}
+                        local options = {
+                            loadFromString=true,
+                            headers=false,
+                            rename={"a","b","c"},
+                            fieldsToKeep={"a","b"}
+                        }
                         local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
@@ -430,7 +444,8 @@ describe("csv features", function()
         for newline, j in pairs(newlines) do
             for quote, k in pairs(quotes) do
                 for _, endline in ipairs(endlines) do
-                    local name = "should handle if the number of renames doesn't equal the number of fields (%s + %s + %s) EOF: %s"
+                    local name = "should handle if the number of renames doesn't equal the number of fields " ..
+                    "(%s + %s + %s) EOF: %s"
                     it(name:format(bom, newline, quote, endline), function()
                         local expectedHeaders = {"a", "b"}
                         local expected = {}

--- a/spec/error_spec.lua
+++ b/spec/error_spec.lua
@@ -58,14 +58,22 @@ end)
 
 it("should error when dealing with quotes", function()
 	local test = function()
-		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true})
+		return ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true})
 	end
-	assert.has_error(test, "ftcsv: can't find closing quote in row 1. Try running with the option ignoreQuotes=true if the source incorrectly uses quotes.")
+	assert.has_error(
+		test,
+		"ftcsv: can't find closing quote in row 1. Try running with the option ignoreQuotes=true " ..
+		"if the source incorrectly uses quotes."
+	)
 end)
 
 it("should error if bufferSize is set when parsing entire files", function()
 	local test = function()
-		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true, bufferSize=34})
+		return ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true, bufferSize=34})
 	end
-	assert.has_error(test, "ftcsv: bufferSize can only be specified using 'parseLine'. When using 'parse', the entire file is read into memory")
+	assert.has_error(
+		test,
+		"ftcsv: bufferSize can only be specified using 'parseLine'. When using 'parse', " ..
+		"the entire file is read into memory"
+	)
 end)

--- a/spec/feature_spec.lua
+++ b/spec/feature_spec.lua
@@ -363,7 +363,9 @@ describe("csv features", function()
 		assert.are.same(expected, actual)
 	end)
 
-	it("should handle only renaming fields from files without headers and only keeping a few fields with an empty header field", function()
+	it("should handle only renaming fields from files without headers and only keeping a few fields with an empty " ..
+	"header field",
+	function()
 		local expected = {}
 		expected[1] = {}
 		expected[1].a = "apple"
@@ -406,7 +408,7 @@ describe("csv features", function()
 		expected[1].B = "banana"
 		expected[1].C = "carrot"
 		local actual = ftcsv.parse(ftcsv.encode(expected, ","), ",", {loadFromString=true})
-		local expected = ftcsv.parse("A,B,C\napple,banana,carrot", ",", {loadFromString=true})
+		expected = ftcsv.parse("A,B,C\napple,banana,carrot", ",", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -417,7 +419,7 @@ describe("csv features", function()
 		expected[1].B = "banana"
 		expected[1].C = "carrot"
 		local actual = ftcsv.parse(ftcsv.encode(expected, ">"), ">", {loadFromString=true})
-		local expected = ftcsv.parse("A,B,C\napple,banana,carrot", ",", {loadFromString=true})
+		expected = ftcsv.parse("A,B,C\napple,banana,carrot", ",", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
@@ -428,13 +430,13 @@ describe("csv features", function()
 		expected[1].B = "banana"
 		expected[1].C = "carrot"
 		local actual = ftcsv.parse(ftcsv.encode(expected, ",", {fieldsToKeep={"A", "B"}}), ",", {loadFromString=true})
-		local expected = ftcsv.parse("A,B\napple,banana", ",", {loadFromString=true})
+		expected = ftcsv.parse("A,B\napple,banana", ",", {loadFromString=true})
 		assert.are.same(expected, actual)
 	end)
 
 	it("should handle encoding files (str test)", function()
 		local expected = '"a","b","c","d"\r\n"1","","foo","""quoted"""\r\n'
-		output = ftcsv.encode({
+		local output = ftcsv.encode({
 			{ a = 1, b = '', c = 'foo', d = '"quoted"' };
 		}, ',')
 		assert.are.same(expected, output)
@@ -442,7 +444,7 @@ describe("csv features", function()
 
 	it("should handle encoding files (str test) with other delimiter", function()
 		local expected = '"a">"b">"c">"d"\r\n"1">"">"foo">"""quoted"""\r\n'
-		output = ftcsv.encode({
+		local output = ftcsv.encode({
 			{ a = 1, b = '', c = 'foo', d = '"quoted"' };
 		}, '>')
 		assert.are.same(expected, output)
@@ -450,7 +452,7 @@ describe("csv features", function()
 
 	it("should handle encoding files without quotes (str test)", function()
 		local expected = 'a,b,c,d\r\n1,,"fo,o","""quoted"""\r\n'
-		output = ftcsv.encode({
+		local output = ftcsv.encode({
 			{ a = 1, b = '', c = 'fo,o', d = '"quoted"' };
 		}, ',', {onlyRequiredQuotes=true})
 		assert.are.same(expected, output)
@@ -458,7 +460,7 @@ describe("csv features", function()
 
 	it("should handle encoding files without quotes with other delimiter (str test)", function()
 		local expected = 'a>b>c>d\r\n1>>fo,o>"""quoted"""\r\n'
-		output = ftcsv.encode({
+		local output = ftcsv.encode({
 			{ a = 1, b = '', c = 'fo,o', d = '"quoted"' };
 		}, '>', {onlyRequiredQuotes=true})
 		assert.are.same(expected, output)
@@ -466,7 +468,7 @@ describe("csv features", function()
 
 	it("should handle encoding files without quotes with certain fields to keep (str test)", function()
 		local expected = "b,c\r\n,foo\r\n"
-		output = ftcsv.encode({
+		local output = ftcsv.encode({
 			{ a = 1, b = '', c = 'foo', d = '"quoted"' };
 		}, ',', {onlyRequiredQuotes=true, fieldsToKeep={"b", "c"}})
 		assert.are.same(expected, output)

--- a/spec/parse_encode_spec.lua
+++ b/spec/parse_encode_spec.lua
@@ -81,7 +81,7 @@ describe("csv encode", function()
 			-- local f = csv.openstring(contents, {separator=",", header=true})
 			-- local parse = {}
 			-- for fields in f:lines() do
-			  -- parse[#parse+1] = fields
+				-- parse[#parse+1] = fields
 			-- end
 			assert.are.same(jsonDecode, reEncoded)
 		end)
@@ -94,11 +94,19 @@ describe("csv encode without quotes", function()
 			local jsonFile = loadFile("spec/json/" .. value .. ".json")
 			local jsonDecode = cjson.decode(jsonFile)
 			-- local parse = staecsv:ftcsv(contents, ",")
-			local reEncodedNoQuotes = ftcsv.parse(ftcsv.encode(jsonDecode, ",", {onlyRequiredQuotes=true}), ",", {loadFromString=true})
+			local reEncodedNoQuotes = ftcsv.parse(
+				ftcsv.encode(
+					jsonDecode,
+					",",
+					{onlyRequiredQuotes=true}
+				),
+				",",
+				{loadFromString=true}
+			)
 			-- local f = csv.openstring(contents, {separator=",", header=true})
 			-- local parse = {}
 			-- for fields in f:lines() do
-			  -- parse[#parse+1] = fields
+				-- parse[#parse+1] = fields
 			-- end
 			assert.are.same(jsonDecode, reEncodedNoQuotes)
 		end)


### PR DESCRIPTION
## Features
* Adds Lua linter to Github Actions for all pull requests and any pushes to master branch

## Fixes
* Remove dead trailing whitespace
* Remove unused variables that were reassiged
* Fix line length to be the default 120
* Fix scope of global variables to be local
* Remove unused testing variables
* Refactor function names for clarity
 
This pull request adds a linter that catches some common mistakes and enforces a max character of 120 per line. (python has 80 chars)  A lot of the settings can be toggled or ignored but I think it is a good baseline to use for any Lua project without causing too much hassle.