### PR TITLE
Make delimiter optional while staying backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ file:close()
 ### Options
  - `fieldsToKeep`
 
-	if `fieldsToKeep` is set in the encode process, only the fields specified will be written out to a file.
+	if `fieldsToKeep` is set in the encode process, only the fields specified will be written out to a file. The `fieldsToKeep` will be written out in the order that is specified.
 
 	```lua
 	local output = ftcsv.encode(everyUser, ",", {fieldsToKeep={"Name", "Phone", "City"}})
@@ -155,7 +155,7 @@ file:close()
     if `onlyRequiredQuotes` is set to `true`, the output will only include quotes around fields that are quotes, have newlines, or contain the delimter.
 
     ```lua
-    local output = ftcsv.encode(everyUser, ",", {noQuotes=true})
+    local output = ftcsv.encode(everyUser, ",", {onlyRequiredQuotes=true})
     ```
 
 

--- a/ftcsv-1.4.0-1.rockspec
+++ b/ftcsv-1.4.0-1.rockspec
@@ -1,16 +1,16 @@
 package = "ftcsv"
-version = "1.3.0-1"
+version = "1.4.0-1"
 
 source = {
 	url = "git://github.com/FourierTransformer/ftcsv.git",
-	tag = "1.3.0"
+	tag = "1.4.0"
 }
 
 description = {
 	summary = "A fast pure lua csv library (parser and encoder)",
 	detailed = [[
    ftcsv is a fast and easy to use csv library for lua. It can read in CSV files,
-   do some basic transformations (rename fields) and can create the csv format.
+   do some basic transformations (rename fields, retain, etc) and can create a CSV file.
    It supports UTF-8, header-less CSVs, and maintaining correct line endings for
    multi-line fields.
 

--- a/spec/dynamic_features_spec.lua
+++ b/spec/dynamic_features_spec.lua
@@ -61,7 +61,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, rename={["a"] = "d", ["b"] = "e", ["c"] = "f"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -123,7 +123,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, fieldsToKeep={"a", "b"}}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)
@@ -347,7 +347,7 @@ describe("csv features", function()
                         end
 
                         local options = {loadFromString=true, headers=false}
-                        local actual, actualHeaders = ftcsv.parse(defaultString, ",", options)
+                        local actual, actualHeaders = ftcsv.parse(defaultString, options)
                         assert.are.same(expected, actual)
                         assert.are.same(expectedHeaders, actualHeaders)
                     end)

--- a/spec/feature_spec.lua
+++ b/spec/feature_spec.lua
@@ -71,6 +71,16 @@ describe("csv features", function()
 		assert.are.same(expected, actual)
 	end)
 
+	it("should handle escaped doublequotes with delimiter in options", function()
+		local expected = {}
+		expected[1] = {}
+		expected[1].a = 'A"B""C'
+		expected[1].b = 'A""B"C'
+		expected[1].c = 'A"""B""C'
+		local actual = ftcsv.parse('a;b;c\n"A""B""""C";"A""""B""C";"A""""""B""""C"', {loadFromString=true, delimiter=";"})
+		assert.are.same(expected, actual)
+	end)
+
 	it("should handle renaming a field", function()
 		local expected = {}
 		expected[1] = {}
@@ -491,5 +501,40 @@ describe("csv features", function()
 		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", {loadFromString=true, ignoreQuotes=true})
 		assert.are.same(expected, actual)
 	end)
+
+	it("should handle ignoring the single quote without specifying the delimeter", function()
+		local expected = {}
+		expected[1] = {}
+		expected[1].a = '"apple'
+		expected[1].b = "banana"
+		expected[1].c = "carrot"
+		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', {loadFromString=true, ignoreQuotes=true})
+		assert.are.same(expected, actual)
+	end)
+
+	it("should handle reusing the options", function()
+		local expected = {}
+		expected[1] = {}
+		expected[1].a = '"apple'
+		expected[1].b = "banana"
+		expected[1].c = "carrot"
+		local options = {loadFromString=true, ignoreQuotes=true}
+		local first = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", options)
+		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', ",", options)
+		assert.are.same(expected, actual)
+	end)
+
+	it("should handle reusing the options without specifying the delimeter", function()
+		local expected = {}
+		expected[1] = {}
+		expected[1].a = '"apple'
+		expected[1].b = "banana"
+		expected[1].c = "carrot"
+		local options = {loadFromString=true, ignoreQuotes=true}
+		local first = ftcsv.parse('a,b,c\n"apple,banana,carrot', options)
+		local actual = ftcsv.parse('a,b,c\n"apple,banana,carrot', options)
+		assert.are.same(expected, actual)
+	end)
+
 
 end)

--- a/spec/parseLine_spec.lua
+++ b/spec/parseLine_spec.lua
@@ -86,3 +86,81 @@ describe("parseLine with options but not bufferSize", function()
         assert.are.same(#json, #parse)
     end)
 end)
+
+describe("parseLine features small, working buffer size without delimiter", function()
+    it("should handle correctness", function()
+        local json = loadFile("spec/json/correctness.json")
+        json = cjson.decode(json)
+        local parse = {}
+        for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=52}) do
+            assert.are.same(json[i], line)
+            parse[i] = line
+        end
+        assert.are.same(#json, #parse)
+        assert.are.same(json, parse)
+    end)
+end)
+
+describe("parseLine features small, nonworking buffer size without delimiter", function()
+    it("should handle correctness", function()
+        local test = function()
+            local parse = {}
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=63}) do
+                parse[i] = line
+            end
+            return parse
+        end
+        assert.has_error(test, "ftcsv: bufferSize needs to be larger to parse this file")
+    end)
+end)
+
+describe("parseLine features smaller, nonworking buffer size without delimiter", function()
+    it("should handle correctness", function()
+        local test = function()
+            local parse = {}
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=50}) do
+                parse[i] = line
+            end
+            return parse
+        end
+        assert.has_error(test, "ftcsv: bufferSize needs to be larger to parse this file")
+    end)
+end)
+
+describe("smaller bufferSize than header and incorrect number of fields without delimiter", function()
+    it("should handle correctness", function()
+        local test = function()
+            local parse = {}
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=23}) do
+                parse[i] = line
+            end
+            return parse
+        end
+        assert.has_error(test, "ftcsv: bufferSize needs to be larger to parse this file")
+    end)
+end)
+
+describe("smaller bufferSize than header, but with correct field numbers without delimiter", function()
+    it("should handle correctness", function()
+        local test = function()
+            local parse = {}
+            for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {bufferSize=30}) do
+                parse[i] = line
+            end
+            return parse
+        end
+        assert.has_error(test, "ftcsv: bufferSize needs to be larger to parse this file")
+    end)
+end)
+
+describe("parseLine with options but not bufferSize without delimiter", function()
+    it("should handle correctness", function()
+        local json = loadFile("spec/json/correctness.json")
+        json = cjson.decode(json)
+    local parse = {}
+    for i, line in ftcsv.parseLine("spec/csvs/correctness.csv", {rename={["Year"] = "Full Year"}}) do
+    parse[i] = line
+    end
+        assert.are.same(#json, #parse)
+    end)
+end)


### PR DESCRIPTION
## Fixes
- Checks the type of the second argument and then handles it either as a delimiter or the options table. Allows the code to remain backwards compatible. (#23)
- Fixes a bug if you reuse the options table where the `bufferSize can only be specified using 'parseLine'` would pop up. (#39)
- Updated README with some clarificatoins

closes #23 and #39