### PR TITLE
Fix code coverage

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -38,6 +38,6 @@ jobs:
     - name: Report test coverage
       if: success()
       continue-on-error: true
-      run: luacov-coveralls -e .luarocks
+      run: luacov-coveralls -e lua_install
       env:
         COVERALLS_REPO_TOKEN: ${{ github.token }}

--- a/spec/parse_encode_spec.lua
+++ b/spec/parse_encode_spec.lua
@@ -115,24 +115,6 @@ describe("csv encode without quotes", function()
 	end
 end)
 
---[[ This breaks simple_crlf.
-describe("csv encode with missing keys", function()
-	for _, value in ipairs(files) do
-		it("should handle " .. value, function()
-			local jsonFile = loadFile("spec/json/" .. value .. ".json")
-			local jsonDecode = cjson.decode(jsonFile)
-			local reEncoded = ftcsv.parse(ftcsv.encode(
-				jsonDecode, ",", {
-					fieldsToKeep = {"a", "b", "c", "d"},
-					allowMissingKeys = true,
-				}
-			), ",", {loadFromString=true})
-			assert.are.same(jsonDecode, reEncoded)
-		end)
-	end
-end)
---]]
-
 describe("csv encode with missing keys", function()
 	it("should handle missing_keys", function()
 		local jsonFile = loadFile("spec/json/missing_keys.json")


### PR DESCRIPTION
We changed how the CI/CD pipelines worked and needed to remove the `lua_install` folder from the coverage report.